### PR TITLE
chore(dependabot): update commit message prefix for `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: daily
   - package-ecosystem: github-actions
     commit-message:
-      prefix: ci(Github Action)
+      prefix: ci(Github Actions)
     directory: /
     open-pull-requests-limit: 1000
     schedule:


### PR DESCRIPTION
This commit corrects the commit message prefix for the `github-actions` ecosystem in the Dependabot configuration. The prefix was updated from `ci(Github Action)` to `ci(Github Actions)` to ensure correct spelling and terminology, improving the consistency and accuracy of generated commit messages.