### PR TITLE
chore(dependabot): update commit message prefix for docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: docker
     commit-message:
-      prefix: chore(dockerfile)
+      prefix: chore(Dockerfile)
     directory: /
     open-pull-requests-limit: 1000
     schedule:


### PR DESCRIPTION
This commit updates the commit message prefix for dependabot PRs related to docker updates. The original prefix used lowercase 'dockerfile', which has been standardized to 'Dockerfile' to align with conventional naming and improve consistency.