### PR TITLE
ci(Github Actions)!: update docker build platforms to include `linux/riscv64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/mips64le, linux/ppc64le, linux/s390x
+          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/riscv64, linux/s390x
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
- Replace `linux/mips64le` with `linux/riscv64` in the list of supported platforms for the Docker image build process
- This change ensures compatibility with RISC-V architecture while maintaining support for other existing platforms This update is necessary to expand architecture support for the Docker image, aligning with current hardware trends and requirements.

BREAKING CHANGE: `linux/mips64le` platform is no longer supported.